### PR TITLE
Setup HTML5 and CSS validation action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "0sc"

--- a/.github/workflows/validate-html-css.yml
+++ b/.github/workflows/validate-html-css.yml
@@ -1,0 +1,27 @@
+name: "Validate HTML and CSS"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validateHTML:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: HTML5 Validation
+        uses: Cyb3r-Jak3/html5validator-action@v7.1.0
+        with:
+          root: .
+
+  validateCSS:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: CSS Validation
+        uses: Cyb3r-Jak3/html5validator-action@v7.1.0
+        with:
+          root: assets/css
+          css: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # READIUM
 
+![Valid HTML5 and CSS](https://github.com/0sc/action/actions/workflows/validate-html-css.yml/badge.svg)
+
 A non-functional clone of medium.com


### PR DESCRIPTION
This PR:
* sets up a [GitHub workflow](https://docs.github.com/en/actions/getting-started-with-github-actions) to perform HTML5 and CSS validation on every pull request against the main branch and direct push on the main branch.
* configure [dependabot](https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot) to keep the GitHub action dependencies up to date
* include a fancy validation [status badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) in the Readme 