### PR TITLE
Add webpage screenshot github action

### DIFF
--- a/.github/workflows/webpage-screenshot.yml
+++ b/.github/workflows/webpage-screenshot.yml
@@ -10,6 +10,7 @@ jobs:
 
     permissions:
       pull-requests: write
+      contents: write
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/webpage-screenshot.yml
+++ b/.github/workflows/webpage-screenshot.yml
@@ -1,0 +1,16 @@
+name: Webpage Screenshot
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Comment Webpage Screenshot
+        uses: saadmk11/comment-webpage-screenshot@v0.5
+        with:
+          upload_to: github_branch
+          capture_changed_html_files: yes

--- a/.github/workflows/webpage-screenshot.yml
+++ b/.github/workflows/webpage-screenshot.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   capture:
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v3
       - name: Comment Webpage Screenshot

--- a/index.html
+++ b/index.html
@@ -30,7 +30,6 @@
           <li class="sm-hidden"><a href="#">Our story</a></li>
           <li class="sm-hidden"><a href="#">Membership</a></li>
           <li class="sm-hidden"><a href="#">Write</a></li>
-          <li class="sm-hidden"><a href="#">Read</a></li>
           <li class="sm-hidden"><a href="#">Sign in </a></li>
           <li><a href="#">Get started</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
           <li class="sm-hidden"><a href="#">Our story</a></li>
           <li class="sm-hidden"><a href="#">Membership</a></li>
           <li class="sm-hidden"><a href="#">Write</a></li>
+          <li class="sm-hidden"><a href="#">Read</a></li>
           <li class="sm-hidden"><a href="#">Sign in </a></li>
           <li><a href="#">Get started</a></li>
         </ul>


### PR DESCRIPTION
This PR adds a GitHub workflow that captures a screenshot of PR changes and posts them as comments to the PR. This should make it easier to review changes visually before(or without) having to pull it and inspect locally.

See sample screenshot comment below :)